### PR TITLE
Add initial Python package scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 node_modules/
 dist/
 build/
+.pytest_cache/
+.mypy_cache/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,26 @@
 
 **AI-Powered Multimodal Investment Advisor**
 
-QuantGPT is an open-source project that combines NLP, time-series forecasting, and reinforcement learning to provide intelligent investment recommendations.
+QuantGPT is an open-source project that combines NLP, time-series forecasting and reinforcement learning to provide intelligent investment recommendations.
 
 ## Features
 - Real-time financial news and Twitter sentiment
 - Stock price forecasting (LSTM, Prophet)
 - Portfolio optimization (Reinforcement Learning)
-- Interactive dashboard (React)
+- Interactive dashboard (Streamlit)
+
+## Development
+
+The codebase follows a simple `src/` layout. Core modules live under `src/quantgpt` and tests reside in `tests/`.
+
+### Setup
+1. Create a virtual environment and install the project in editable mode:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .
+   ```
+2. Run the unit tests with `pytest`:
+   ```bash
+   pytest
+   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "quantgpt"
+version = "0.1.0"
+description = "AI-powered multimodal investment advisor"
+authors = [{ name = "Sawan Kumar" }]
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/quantgpt/__init__.py
+++ b/src/quantgpt/__init__.py
@@ -1,0 +1,8 @@
+"""QuantGPT core package."""
+
+__all__ = [
+    "nlp",
+    "forecasting",
+    "portfolio",
+    "dashboard",
+]

--- a/src/quantgpt/cli.py
+++ b/src/quantgpt/cli.py
@@ -1,0 +1,24 @@
+"""Command line interface for QuantGPT."""
+import argparse
+from .nlp import analyze_sentiment
+from .forecasting import PriceForecaster
+from .portfolio import optimize_portfolio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="QuantGPT CLI")
+    parser.add_argument("--sentiment", help="Text to analyze")
+    parser.add_argument("--forecast", nargs="*", type=float, help="Prices for forecasting")
+    args = parser.parse_args()
+
+    if args.sentiment:
+        score = analyze_sentiment(args.sentiment)
+        print(f"Sentiment score: {score}")
+
+    if args.forecast:
+        model = PriceForecaster(args.forecast)
+        print(model.forecast())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/quantgpt/dashboard/__init__.py
+++ b/src/quantgpt/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard application."""

--- a/src/quantgpt/dashboard/app.py
+++ b/src/quantgpt/dashboard/app.py
@@ -1,0 +1,12 @@
+"""Placeholder dashboard using Streamlit."""
+import streamlit as st
+
+
+def main() -> None:
+    """Run the dashboard app."""
+    st.title("QuantGPT Dashboard")
+    st.write("Welcome to QuantGPT")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/quantgpt/forecasting/__init__.py
+++ b/src/quantgpt/forecasting/__init__.py
@@ -1,0 +1,4 @@
+"""Forecasting models for QuantGPT."""
+from .models import PriceForecaster
+
+__all__ = ["PriceForecaster"]

--- a/src/quantgpt/forecasting/models.py
+++ b/src/quantgpt/forecasting/models.py
@@ -1,0 +1,15 @@
+"""Forecasting models."""
+from typing import Sequence
+
+
+class PriceForecaster:
+    """Placeholder forecasting model."""
+
+    def __init__(self, prices: Sequence[float]):
+        self.prices = list(prices)
+
+    def forecast(self, steps: int = 1) -> Sequence[float]:
+        """Return a naive forecast using the last observed price."""
+        if not self.prices:
+            raise ValueError("No price data provided")
+        return [self.prices[-1]] * steps

--- a/src/quantgpt/nlp/__init__.py
+++ b/src/quantgpt/nlp/__init__.py
@@ -1,0 +1,4 @@
+"""NLP utilities for QuantGPT."""
+from .sentiment import analyze_sentiment
+
+__all__ = ["analyze_sentiment"]

--- a/src/quantgpt/nlp/sentiment.py
+++ b/src/quantgpt/nlp/sentiment.py
@@ -1,0 +1,18 @@
+"""Sentiment analysis utilities."""
+from typing import Any
+
+def analyze_sentiment(text: str) -> float:
+    """Analyze sentiment of given text.
+
+    Parameters
+    ----------
+    text : str
+        Input text.
+
+    Returns
+    -------
+    float
+        Sentiment score between -1 and 1.
+    """
+    # TODO: Implement sentiment analysis
+    return 0.0

--- a/src/quantgpt/portfolio/__init__.py
+++ b/src/quantgpt/portfolio/__init__.py
@@ -1,0 +1,4 @@
+"""Portfolio optimization tools."""
+from .optimizer import optimize_portfolio
+
+__all__ = ["optimize_portfolio"]

--- a/src/quantgpt/portfolio/optimizer.py
+++ b/src/quantgpt/portfolio/optimizer.py
@@ -1,0 +1,11 @@
+"""Portfolio optimizer."""
+from typing import Sequence
+
+
+def optimize_portfolio(prices: Sequence[float]) -> Sequence[float]:
+    """Return naive equal-weight allocation."""
+    n = len(prices)
+    if n == 0:
+        raise ValueError("No price data provided")
+    weight = 1.0 / n
+    return [weight] * n

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Add the src directory to sys.path so tests can import the package without installation
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,14 @@
+"""Basic import tests for QuantGPT."""
+
+
+def test_imports() -> None:
+    import quantgpt
+    import quantgpt.nlp
+    import quantgpt.forecasting
+    import quantgpt.portfolio
+    import quantgpt.dashboard
+
+    assert hasattr(quantgpt, "nlp")
+    assert hasattr(quantgpt, "forecasting")
+    assert hasattr(quantgpt, "portfolio")
+    assert hasattr(quantgpt, "dashboard")


### PR DESCRIPTION
## Summary
- add a `src/` layout with placeholder modules
- create CLI entrypoint and basic dashboard stub
- configure packaging via `pyproject.toml`
- add unit tests and path setup
- document setup steps in README
- expand `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710d09084c832eb1a6e90dcf8652d6